### PR TITLE
Fix utf8 error handling

### DIFF
--- a/hnormalise.cabal
+++ b/hnormalise.cabal
@@ -1,5 +1,5 @@
 name:                hnormalise
-version:             0.5.6.1
+version:             0.6.0.0
 synopsis:            Log message normalisation tool producing structured JSON messages
 description:         Log message normalisation tool producing structured JSON messages
 homepage:            https://github.com/itkovian/hnormalise#readme
@@ -7,7 +7,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Andy Georges
 maintainer:          itkovian@gmail.com
-copyright:           2017-2019 Ghent University
+copyright:           2017-2021 Ghent University
 category:            Command line
 build-type:          Simple
 extra-source-files:  README.md

--- a/hnormalise.spec
+++ b/hnormalise.spec
@@ -34,7 +34,7 @@
 
 Summary: Log normalisation tool
 Name: hnormalise
-Version: 0.5.6.1
+Version: 0.6.0.0
 Release: 1
 
 Group: Applications/System

--- a/src/HNormalise.hs
+++ b/src/HNormalise.hs
@@ -50,7 +50,8 @@ import           Data.Attoparsec.Text
 import qualified Data.ByteString.Char8      as SBS
 import qualified Data.ByteString.Lazy.Char8 as BS
 import           Data.Text                  (Text, empty)
-import           Data.Text.Encoding         (encodeUtf8, decodeUtf8)
+import           Data.Text.Encoding         (encodeUtf8, decodeUtf8With)
+import           Data.Text.Encoding.Error   (lenientDecode)
 import           Data.Text.Lazy             (toStrict)
 
 --------------------------------------------------------------------------------
@@ -89,7 +90,7 @@ normaliseText :: Maybe [(Text, Text)]                        -- ^ Output fields
               -> SBS.ByteString                              -- ^ Input
               -> Either SBS.ByteString NormalisedRsyslog     -- ^ Transformed or Original result
 normaliseText fs logLine =
-    case parse (parseRsyslogLogstashString fs) $ decodeUtf8 logLine of
+    case parse (parseRsyslogLogstashString fs) $ decodeUtf8With lenientDecode logLine of
         Done _ r    -> Right r
         Partial c   -> case c empty of
                             Done _ r -> Right r

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-13.11
+resolver: lts-16.11
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
When the rsyslog data is invalid UTF-8, hnormalise bails. This can happen when a user runs a windows application on the HPC system, pushing some windows encoded text through rsyslog.